### PR TITLE
Ability to disable ca-verification in Guzzle

### DIFF
--- a/lib/PostcodeAddress.php
+++ b/lib/PostcodeAddress.php
@@ -36,6 +36,11 @@ class PostcodeAddress
     public static $timeOutDefault = 5;
 
     /**
+     * @var bool Verify certificates
+     */
+    public static $verifyDefault = true;
+
+    /**
      * PostcodeAddress constructor.
      * @throws Exception
      */
@@ -210,6 +215,7 @@ TAG;
     {
         return new Client([
             'timeout' => self::$timeOutDefault,
+            'verify' => self::$verifyDefault,
         ]);
     }
 


### PR DESCRIPTION
Ubuntu cannot verify Sectigo certificate - https://serverfault.com/questions/1118578/ubuntu-cannot-verify-sectigo-certificate